### PR TITLE
Index on shortenUrl

### DIFF
--- a/src/models/urls.go
+++ b/src/models/urls.go
@@ -6,7 +6,7 @@ import "gorm.io/gorm"
 type Url struct {
 	gorm.Model
 	ID        uint64 `gorm:"primaryKey;autoIncrement:false"`
-	ShortURL  string `gorm:"unique,not null"`
+	ShortURL  string `gorm:"uniqueIndex,not null"`
 	LongURL   string `gorm:"not null"`
 	CreatorID uint
 	Creator   User `gorm:"foreignKey:CreatorID"`


### PR DESCRIPTION
As ShortenUrl is a string, searching and resolving URLs might become costly operation soon. We can delay that by adding a Unique Index now which would make the querying much faster.
Later in long run based on enough traffic, we can consider other options.

