### PR TITLE
feat: toggle button for dark mode

### DIFF
--- a/public_html/index.html
+++ b/public_html/index.html
@@ -17,9 +17,20 @@
 
 <body>
     <!-- Header -->
-    <header>
+    <header>     
         <div class="container-fluid p-4 bg-body-tertiary">
-            <h1 class="display-1 text-center fw-bold text-body-tertiary">1px.li</h1>
+            <div class="d-flex align-items-center justify-content-center gap-2">
+                <h1 class="display-1 text-center fw-bold text-body-tertiary">1px.li</h1>
+                <div class="dropdown">
+                    <button class="btn btn-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
+                        <i id="icon" class="bi bi-brightness-high"></i>
+                    </button>
+                    <ul class="dropdown-menu">
+                      <li><button class="dropdown-item" type="button" onclick="changeValue('brightness-high', 'light')"><i class="bi bi-brightness-high"></i> Light</button></li>
+                      <li><button class="dropdown-item" type="button" onclick="changeValue('moon-stars', 'dark')"><i class="bi bi-moon-stars"></i> Dark</button></li>
+                    </ul>
+                </div>
+            </div>           
             <p class="lead text-center text-secondary-emphasis">
                 onepixel·link - a no nonsense API-first URL shortner for geeks
             </p>

--- a/public_html/index.html
+++ b/public_html/index.html
@@ -21,7 +21,7 @@
         <div class="container-fluid p-4 bg-body-tertiary">
             <div class="d-flex align-items-center justify-content-center gap-2">
                 <h1 class="display-1 text-center fw-bold text-body-tertiary">1px.li</h1>
-                <div class="dropdown">
+                <div class="dropdown position-absolute top-0 end-0 m-2 m-md-4">
                     <button class="btn btn-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
                         <i id="icon" class="bi bi-brightness-high"></i>
                     </button>

--- a/public_html/script.js
+++ b/public_html/script.js
@@ -17,3 +17,10 @@ window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', eve
     htmlElement.setAttribute("data-bs-theme", colorScheme);
   }
 });
+
+function changeValue (iconClass, color){
+  document.getElementById("icon").className = 'bi bi-' + iconClass;
+  if (htmlElement) {
+    htmlElement.setAttribute("data-bs-theme", color);
+  }
+}


### PR DESCRIPTION
## Closes #45 
I have added the toggle button for light and dark mode. I have added it right next to the header so it is easily accessible.
This is how it looks on:
1. Desktop screen

![Screenshot from 2024-01-25 03-43-40](https://github.com/championswimmer/onepixel_backend/assets/85514520/b48fe117-d091-400c-a440-43ba8f0d6999)

2. Mobile screen

![Screenshot from 2024-01-25 03-43-52](https://github.com/championswimmer/onepixel_backend/assets/85514520/4b472ac1-05fd-48df-87fd-59332c52ba6d)

## Changes made

1. Added a bootstrap dropdown component.
2. Added `onclick` to listen for changes in the dropdown button and update the theme accordingly.