### PR TITLE
feat: toggle button for light/dark mode

### DIFF
--- a/public_html/index.html
+++ b/public_html/index.html
@@ -19,7 +19,7 @@
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-51J34YD93D"></script>
     <script>
         window.dataLayer = window.dataLayer || [];
-        function gtag(){dataLayer.push(arguments);}
+        function gtag() { dataLayer.push(arguments); }
         gtag('js', new Date());
 
         gtag('config', 'G-51J34YD93D');
@@ -31,6 +31,11 @@
     <!-- Header -->
     <header>
         <div class="container-fluid p-4 bg-body-tertiary">
+            <div class="position-absolute top-0 end-0 m-2 m-md-4">
+                <button id="theme-switch" class="btn btn-secondary" type="button" onclick="changeTheme()">
+                    <i id="mode-icon" class="bi bi-sun-fill"></i>
+                </button>
+            </div>
             <h1 class="display-1 text-center fw-bold text-body-tertiary">1px.li</h1>
             <p class="lead text-center text-secondary-emphasis">
                 onepixel·link - a no nonsense API-first URL shortener for geeks

--- a/public_html/script.js
+++ b/public_html/script.js
@@ -17,3 +17,18 @@ window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', eve
     htmlElement.setAttribute("data-bs-theme", colorScheme);
   }
 });
+
+function changeTheme() {
+  const currentTheme = htmlElement.getAttribute("data-bs-theme");
+  if (currentTheme === "dark") {
+    document.getElementById("mode-icon").className = "bi bi-moon-stars-fill";
+    if (htmlElement) {
+      htmlElement.setAttribute("data-bs-theme", "light");
+    }
+  } else {
+    document.getElementById("mode-icon").className = "bi bi-sun-fill";
+    if (htmlElement) {
+      htmlElement.setAttribute("data-bs-theme", "dark");
+    }
+  }
+}


### PR DESCRIPTION
Closes https://github.com/championswimmer/onepixel_backend/issues/45

Added a variation to have a single button instead of a dropdown (https://github.com/championswimmer/onepixel_backend/pull/48 by @aqsaaqeel). If this approach doesn't fit then close this PR.

It looks like this:
- Desktop
![image](https://github.com/championswimmer/onepixel_backend/assets/63816545/8086eb2d-c0cb-46b5-8e70-f62c69bff45b)
- Mobile
![image](https://github.com/championswimmer/onepixel_backend/assets/63816545/908d32c4-1e45-49ea-ae07-883b0ee763d5)
