### PR TITLE
Fixes#54

### DIFF
--- a/src/controllers/urls.go
+++ b/src/controllers/urls.go
@@ -43,7 +43,7 @@ func (e *UrlError) ErrorDetails() (int, string) {
 
 var (
 	UrlNotFound = &UrlError{
-		status:  404,
+		status:  fiber.StatusNotFound,
 		message: "URL not found",
 	}
 	UrlExistsError = &UrlError{
@@ -55,7 +55,7 @@ var (
 		message: "this shortURL is not allowed to be created",
 	}
 	SpecificShortUrlLengthError = &UrlError{
-		status: 400,
+		status: fiber.StatusBadRequest,
 		message: "String longer than 10 characters",
 	}
 )
@@ -95,8 +95,13 @@ func (c *UrlsController) CreateSpecificShortUrl(shortUrl string, longUrl string,
 	id, err := utils.Radix64Decode(shortUrl)
 
 	if err != nil {
-		applogger.Error("CreateSpecificShortUrl: ", err)
-		return nil, SpecificShortUrlLengthError
+		if err.Error() == SpecificShortUrlLengthError.message {
+			applogger.Error("CreateSpecificShortUrl: ", err)
+			return nil, SpecificShortUrlLengthError
+		} else {
+			applogger.Error("CreateSpecificShortUrl: ", err)
+			return nil, err
+		}
 	}
 	
 	url = &models.Url{
@@ -148,8 +153,13 @@ func (c *UrlsController) GetUrlWithShortCode(shortcode string) (url *models.Url,
 	id, err := utils.Radix64Decode(shortcode)
 
 	if err != nil {
-		applogger.Error("GetUrlWithShortCode: ", err)
-		return nil, SpecificShortUrlLengthError
+		if err.Error() == SpecificShortUrlLengthError.message {
+			applogger.Error("GetUrlWithShortCode: ", err)
+			return nil, SpecificShortUrlLengthError
+		} else {
+			applogger.Error("GetUrlWithShortCode: ", err)
+			return nil, err
+		}
 	}
 
 	res := c.db.First(url, id)

--- a/src/controllers/urls.go
+++ b/src/controllers/urls.go
@@ -54,6 +54,10 @@ var (
 		status:  fiber.ErrForbidden.Code,
 		message: "this shortURL is not allowed to be created",
 	}
+	SpecificShortUrlLengthError = &UrlError{
+		status: 400,
+		message: "String longer than 10 characters",
+	}
 )
 
 var initDefaultUrlGroupOnce sync.Once
@@ -92,7 +96,7 @@ func (c *UrlsController) CreateSpecificShortUrl(shortUrl string, longUrl string,
 
 	if err != nil {
 		applogger.Error("CreateSpecificShortUrl: ", err)
-		return nil, err
+		return nil, SpecificShortUrlLengthError
 	}
 	
 	url = &models.Url{
@@ -145,9 +149,9 @@ func (c *UrlsController) GetUrlWithShortCode(shortcode string) (url *models.Url,
 
 	if err != nil {
 		applogger.Error("GetUrlWithShortCode: ", err)
-		return nil, err
+		return nil, SpecificShortUrlLengthError
 	}
-	
+
 	res := c.db.First(url, id)
 	if res.Error != nil {
 		if errors.Is(res.Error, gorm.ErrRecordNotFound) {

--- a/src/controllers/urls.go
+++ b/src/controllers/urls.go
@@ -95,7 +95,7 @@ func (c *UrlsController) CreateSpecificShortUrl(shortUrl string, longUrl string,
 	id, err := utils.Radix64Decode(shortUrl)
 
 	if err != nil {
-		if err.Error() == SpecificShortUrlLengthError.message {
+		if errors.Is(err, utils.Radix64StringTooLongError) {
 			applogger.Error("CreateSpecificShortUrl: ", err)
 			return nil, SpecificShortUrlLengthError
 		} else {
@@ -153,7 +153,7 @@ func (c *UrlsController) GetUrlWithShortCode(shortcode string) (url *models.Url,
 	id, err := utils.Radix64Decode(shortcode)
 
 	if err != nil {
-		if err.Error() == SpecificShortUrlLengthError.message {
+		if errors.Is(err, utils.Radix64StringTooLongError) {
 			applogger.Error("GetUrlWithShortCode: ", err)
 			return nil, SpecificShortUrlLengthError
 		} else {

--- a/src/controllers/urls.go
+++ b/src/controllers/urls.go
@@ -88,8 +88,15 @@ func CreateUrlsController() *UrlsController {
 }
 
 func (c *UrlsController) CreateSpecificShortUrl(shortUrl string, longUrl string, userId uint64) (url *models.Url, err error) {
+	id, err := utils.Radix64Decode(shortUrl)
+
+	if err != nil {
+		applogger.Error("CreateSpecificShortUrl: ", err)
+		return nil, err
+	}
+	
 	url = &models.Url{
-		ID:         lo.Must(utils.Radix64Decode(shortUrl)),
+		ID:         id,
 		ShortURL:   shortUrl,
 		LongURL:    longUrl,
 		CreatorID:  userId,
@@ -134,7 +141,13 @@ func (c *UrlsController) CreateRandomShortUrl(longUrl string, userId uint64) (ur
 
 func (c *UrlsController) GetUrlWithShortCode(shortcode string) (url *models.Url, err error) {
 	url = &models.Url{}
-	id := lo.Must(utils.Radix64Decode(shortcode))
+	id, err := utils.Radix64Decode(shortcode)
+
+	if err != nil {
+		applogger.Error("GetUrlWithShortCode: ", err)
+		return nil, err
+	}
+	
 	res := c.db.First(url, id)
 	if res.Error != nil {
 		if errors.Is(res.Error, gorm.ErrRecordNotFound) {

--- a/src/routes/api/urls.go
+++ b/src/routes/api/urls.go
@@ -122,6 +122,9 @@ func createSpecificUrl(ctx *fiber.Ctx) error {
 			if errors.Is(e, controllers.UrlForbiddenError) {
 				return ctx.Status(fiber.StatusForbidden).JSON(dtos.CreateErrorResponse(e.ErrorDetails()))
 			}
+			if errors.Is(e, controllers.SpecificShortUrlLengthError) {
+				return ctx.Status(fiber.StatusBadRequest).JSON(dtos.CreateErrorResponse(e.ErrorDetails()))
+			}
 		} else {
 			return ctx.Status(fiber.StatusInternalServerError).JSON(dtos.CreateErrorResponse(fiber.StatusInternalServerError, "something went wrong"))
 		}

--- a/src/routes/redirect/redirect.go
+++ b/src/routes/redirect/redirect.go
@@ -36,11 +36,7 @@ func redirectShortCode(ctx *fiber.Ctx) error {
 	if urlErr != nil {
 		var e *controllers.UrlError
 		if errors.As(urlErr, &e) {
-			if errors.Is(e, controllers.SpecificShortUrlLengthError) {
-				return ctx.Status(fiber.StatusBadRequest).JSON(dtos.CreateErrorResponse(e.ErrorDetails()))
-			} else {
-				return ctx.Status(fiber.StatusNotFound).JSON(dtos.CreateErrorResponse(e.ErrorDetails()))
-			}
+			return ctx.Status(fiber.StatusNotFound).JSON(dtos.CreateErrorResponse(e.ErrorDetails()))
 		}
 		return ctx.Status(fiber.StatusInternalServerError).JSON(dtos.CreateErrorResponse(fiber.StatusInternalServerError, urlErr.Error()))
 	}

--- a/src/routes/redirect/redirect.go
+++ b/src/routes/redirect/redirect.go
@@ -36,7 +36,11 @@ func redirectShortCode(ctx *fiber.Ctx) error {
 	if urlErr != nil {
 		var e *controllers.UrlError
 		if errors.As(urlErr, &e) {
-			return ctx.Status(fiber.StatusNotFound).JSON(dtos.CreateErrorResponse(e.ErrorDetails()))
+			if errors.Is(e, controllers.SpecificShortUrlLengthError) {
+				return ctx.Status(fiber.StatusBadRequest).JSON(dtos.CreateErrorResponse(e.ErrorDetails()))
+			} else {
+				return ctx.Status(fiber.StatusNotFound).JSON(dtos.CreateErrorResponse(e.ErrorDetails()))
+			}
 		}
 		return ctx.Status(fiber.StatusInternalServerError).JSON(dtos.CreateErrorResponse(fiber.StatusInternalServerError, urlErr.Error()))
 	}


### PR DESCRIPTION
fixes #54

This PR fixes application panic and crash when the string character > 10.

Response => 

```
{
    "status": 400,
    "message": "String longer than 10 characters"
}
```
Console Logs => 

```
2024/02/26 13:20:43 app_logger.go:55: [ERROR] CreateSpecificShortUrl:  String longer than 10 characters
```

