### PR TITLE
infra: local dev with sqlite+duckdb

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ Simplest way to get it running is
 
 ### Run with hot-reload for local development 
 
+### With Docker
+
 We will use docker to run an instance of our databases, but we will run the project using [air](https://github.com/cosmtrek/air) locally  
 
 1. make the following directories where your database will be stored
@@ -72,5 +74,19 @@ We will use docker to run an instance of our databases, but we will run the proj
 2. run `docker-compose up -d postgres clickhouse`
 3. run `air` in the root directory of the project <sup>1</sup>
 
+### Without Docker
+
+We will be using the embedded databases for local development without docker
+
+1. Make the following changes in `.onepixel.local.env`
+   ```env
+   DB_DIALECT=sqlite
+   DATABASE_URL="app.db"
+   USE_FILE_DB=true
+   
+   EVENTS_DB_DIALECT=duckdb
+   EVENTDB_URL="events.db"
+   ```
+2. run `air` in the root directory of the project <sup>1</sup>
 
 > Note[1]: you can also run `go run src/main.go` but it will not reload on changes

--- a/onepixel.local.env
+++ b/onepixel.local.env
@@ -7,6 +7,7 @@ ADMIN_USER_EMAIL=admin@onepixel.link
 DB_LOGGING=error
 DB_DIALECT=postgres
 DATABASE_URL="host=127.0.0.1 user=postgres password=postgres dbname=onepixel port=5432 sslmode=disable TimeZone=UTC"
+USE_FILE_DB=false
 
 ADMIN_API_KEY="8DC4FCD4-DD71-4C18-B9C0-C38EF6790815"
 

--- a/src/config/vars.go
+++ b/src/config/vars.go
@@ -12,6 +12,7 @@ var Env string
 var DBLogging string
 var DBDialect string
 var DBUrl string
+var UseFileDB bool
 
 var EventDBUrl string
 var EventDBDialect string
@@ -40,6 +41,7 @@ func init() {
 		os.Getenv("DATABASE_PRIVATE_URL"),
 		os.Getenv("DATABASE_URL"),
 	)
+	UseFileDB, _ = strconv.ParseBool(os.Getenv("USE_FILE_DB"))
 	EventDBDialect = os.Getenv("EVENTDB_DIALECT")
 	EventDBUrl, _ = lo.Coalesce(
 		os.Getenv("EVENTDB_PRIVATE_URL"),

--- a/src/db/init.go
+++ b/src/db/init.go
@@ -1,13 +1,14 @@
 package db
 
 import (
+	"os"
+	"sync"
+
 	"github.com/oschwald/geoip2-golang"
 	"onepixel_backend/src/config"
 	"onepixel_backend/src/db/models"
 	"onepixel_backend/src/utils"
 	"onepixel_backend/src/utils/applogger"
-	"os"
-	"sync"
 
 	"github.com/samber/lo"
 	"gorm.io/gorm"
@@ -44,8 +45,13 @@ func InjectDBProvider(name string, provider DatabaseProvider) {
 }
 
 func init() {
-	InjectDBProvider("postgres", ProvidePostgresDB)
-	InjectDBProvider("clickhouse", ProvideClickhouseDB)
+	if config.UseFileDB {
+		InjectDBProvider("sqlite", ProvideSqliteDB)
+		InjectDBProvider("duckdb", ProvideDuckDB)
+	} else {
+		InjectDBProvider("postgres", ProvidePostgresDB)
+		InjectDBProvider("clickhouse", ProvideClickhouseDB)
+	}
 }
 
 func GetAppDB() *gorm.DB {

--- a/src/db/providers.go
+++ b/src/db/providers.go
@@ -1,12 +1,15 @@
 package db
 
 import (
+	"time"
+
+	"github.com/championswimmer/duckdb-driver/duckdb"
 	"github.com/samber/lo"
 	"gorm.io/driver/clickhouse"
 	"gorm.io/driver/postgres"
+	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
 	"onepixel_backend/src/utils/applogger"
-	"time"
 )
 
 var (
@@ -42,4 +45,14 @@ func ProvideClickhouseDB(dbUrl string, config *gorm.Config) *gorm.DB {
 	return attemptToOpen(func() (*gorm.DB, error) {
 		return gorm.Open(clickhouse.Open(dbUrl), config)
 	})
+}
+
+func ProvideSqliteDB(dbUrl string, config *gorm.Config) *gorm.DB {
+	applogger.Warn("App: Using sqlite db")
+	return lo.Must(gorm.Open(sqlite.Open(dbUrl), config))
+}
+
+func ProvideDuckDB(dbUrl string, config *gorm.Config) *gorm.DB {
+	applogger.Warn("App: Using duckdb db")
+	return lo.Must(gorm.Open(duckdb.Open(dbUrl), config))
 }


### PR DESCRIPTION
Closes #61 

Allows using file based embedded databases with hot reload for local development.
Whether to use file based db or not is being controlled by the config file.

I have tested this locally and redirects are working fine b/w application restarts.