### PR TITLE
Add URL groups and prod rollout migration

### DIFF
--- a/.agents/plans/01-url-groups.md
+++ b/.agents/plans/01-url-groups.md
@@ -6,7 +6,7 @@ steps:
   - step: "Update models, constraints, and migration/index strategy"
     done: true
   - step: "Implement controller logic for group ownership and scoped URL operations"
-    done: false
+    done: true
   - step: "Wire API handlers, auth checks, validators, and DTOs"
     done: false
   - step: "Update redirect resolution for `/short` and `/group/short` paths"

--- a/.agents/plans/01-url-groups.md
+++ b/.agents/plans/01-url-groups.md
@@ -2,7 +2,7 @@
 title: "01 - URL Groups"
 steps:
   - step: "Align route + API contracts for grouped and ungrouped URLs"
-    done: false
+    done: true
   - step: "Update models, constraints, and migration/index strategy"
     done: false
   - step: "Implement controller logic for group ownership and scoped URL operations"

--- a/.agents/plans/01-url-groups.md
+++ b/.agents/plans/01-url-groups.md
@@ -4,7 +4,7 @@ steps:
   - step: "Align route + API contracts for grouped and ungrouped URLs"
     done: true
   - step: "Update models, constraints, and migration/index strategy"
-    done: false
+    done: true
   - step: "Implement controller logic for group ownership and scoped URL operations"
     done: false
   - step: "Wire API handlers, auth checks, validators, and DTOs"

--- a/.agents/plans/01-url-groups.md
+++ b/.agents/plans/01-url-groups.md
@@ -8,7 +8,7 @@ steps:
   - step: "Implement controller logic for group ownership and scoped URL operations"
     done: true
   - step: "Wire API handlers, auth checks, validators, and DTOs"
-    done: false
+    done: true
   - step: "Update redirect resolution for `/short` and `/group/short` paths"
     done: false
   - step: "Add/adjust unit + e2e tests and finalize docs"

--- a/.agents/plans/01-url-groups.md
+++ b/.agents/plans/01-url-groups.md
@@ -10,7 +10,7 @@ steps:
   - step: "Wire API handlers, auth checks, validators, and DTOs"
     done: true
   - step: "Update redirect resolution for `/short` and `/group/short` paths"
-    done: false
+    done: true
   - step: "Add/adjust unit + e2e tests and finalize docs"
     done: false
 ---

--- a/.agents/plans/01-url-groups.md
+++ b/.agents/plans/01-url-groups.md
@@ -12,7 +12,7 @@ steps:
   - step: "Update redirect resolution for `/short` and `/group/short` paths"
     done: true
   - step: "Add/adjust unit + e2e tests and finalize docs"
-    done: false
+    done: true
 ---
 
 # 01 - URL Groups

--- a/.gitignore
+++ b/.gitignore
@@ -197,3 +197,4 @@ fabric.properties
 /events.db.wal
 /duckdb-driver
 /GeoLite2-City.mmdb
+/onepixel.production.env

--- a/maintenance/url_groups_prod.postgres.sql
+++ b/maintenance/url_groups_prod.postgres.sql
@@ -1,0 +1,30 @@
+-- Production URL groups migration for Postgres.
+--
+-- Audit notes from 2026-03-30:
+-- - no legacy global short_url index was present on public.urls
+-- - default url group row (id = 0) already exists
+-- - no duplicate url_groups.name rows exist
+-- - no duplicate (url_group_id, short_url) rows exist
+--
+-- Run with:
+--   psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f maintenance/url_groups_prod.postgres.sql
+
+INSERT INTO public.url_groups (id, created_at, updated_at, deleted_at, name, creator_id)
+VALUES (0, NOW(), NOW(), NULL, '0', 0)
+ON CONFLICT (id) DO UPDATE
+SET
+    updated_at = EXCLUDED.updated_at,
+    deleted_at = NULL,
+    name = EXCLUDED.name,
+    creator_id = EXCLUDED.creator_id;
+
+DROP INDEX IF EXISTS public.idx_urls_short_url;
+DROP INDEX IF EXISTS public.uni_urls_short_url;
+DROP INDEX IF EXISTS public.short_url;
+DROP INDEX IF EXISTS public."ShortURL";
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_url_groups_short_path
+    ON public.url_groups USING btree (name);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_urls_group_shortcode
+    ON public.urls USING btree (url_group_id, short_url);

--- a/src/controllers/events.go
+++ b/src/controllers/events.go
@@ -38,6 +38,13 @@ type EventRedirectData struct {
 	Referer    string
 }
 
+func CanonicalShortURL(urlGroup *models.UrlGroup, shortCode string) string {
+	if urlGroup == nil || urlGroup.ID == 0 || urlGroup.ShortPath == "" {
+		return shortCode
+	}
+	return urlGroup.ShortPath + "/" + shortCode
+}
+
 // synced is a synchronized locker to access user-specific views
 var synced = lo.Synchronize()
 

--- a/src/controllers/urls.go
+++ b/src/controllers/urls.go
@@ -60,6 +60,10 @@ var (
 		status:  fiber.ErrForbidden.Code,
 		message: "this shortURL is not allowed to be created",
 	}
+	UrlGroupForbiddenError = &UrlError{
+		status:  fiber.ErrForbidden.Code,
+		message: "URL group does not belong to the user",
+	}
 	UrlGroupNotFound = &UrlError{
 		status:  fiber.StatusNotFound,
 		message: "URL group not found",
@@ -228,7 +232,7 @@ func (c *UrlsController) GetUrlInfo(shortcode string) (longUrl string, hitCount 
 
 func (c *UrlsController) GetUrls(userId *uint64) ([]models.Url, error) {
 	var urls []models.Url
-	query := c.db
+	query := c.db.Preload("UrlGroup")
 	if userId != nil {
 		query = query.Where("creator_id=?", *userId)
 	}
@@ -253,7 +257,7 @@ func (c *UrlsController) ensureUrlGroupOwnership(urlGroupID uint64, userID uint6
 		return res.Error
 	}
 	if urlGroup.CreatorID != userID {
-		return UrlForbiddenError
+		return UrlGroupForbiddenError
 	}
 	return nil
 }

--- a/src/controllers/urls.go
+++ b/src/controllers/urls.go
@@ -20,6 +20,7 @@ import (
 //   - 6: 64^6 = 68,719,476,736
 const _currentMaxUrlLength = 6
 const _defaultUrlGroupId = 0
+const _maxRandomShortUrlRetries = 10
 
 var _randMax = int(math.Pow(64, _currentMaxUrlLength))
 
@@ -51,9 +52,21 @@ var (
 		status:  fiber.ErrConflict.Code,
 		message: "URL already exists",
 	}
+	UrlGroupExistsError = &UrlError{
+		status:  fiber.ErrConflict.Code,
+		message: "URL group already exists",
+	}
 	UrlForbiddenError = &UrlError{
 		status:  fiber.ErrForbidden.Code,
 		message: "this shortURL is not allowed to be created",
+	}
+	UrlGroupNotFound = &UrlError{
+		status:  fiber.StatusNotFound,
+		message: "URL group not found",
+	}
+	RandomShortUrlExhaustedError = &UrlError{
+		status:  fiber.StatusInternalServerError,
+		message: "failed to generate a unique short URL",
 	}
 )
 
@@ -90,12 +103,20 @@ func CreateUrlsController() *UrlsController {
 }
 
 func (c *UrlsController) CreateSpecificShortUrl(shortUrl string, longUrl string, userId uint64) (url *models.Url, err error) {
+	return c.CreateSpecificShortUrlInGroup(shortUrl, longUrl, userId, _defaultUrlGroupId)
+}
+
+func (c *UrlsController) CreateSpecificShortUrlInGroup(shortUrl string, longUrl string, userId uint64, urlGroupID uint64) (url *models.Url, err error) {
+	if err := c.ensureUrlGroupOwnership(urlGroupID, userId); err != nil {
+		return nil, err
+	}
+
 	url = &models.Url{
 		ID:         lo.Must(utils.Radix64Decode(shortUrl)),
 		ShortURL:   shortUrl,
 		LongURL:    longUrl,
 		CreatorID:  userId,
-		UrlGroupID: 0,
+		UrlGroupID: urlGroupID,
 	}
 
 	res := c.db.Create(url)
@@ -111,33 +132,46 @@ func (c *UrlsController) CreateSpecificShortUrl(shortUrl string, longUrl string,
 }
 
 func (c *UrlsController) CreateRandomShortUrl(longUrl string, userId uint64) (url *models.Url, err error) {
-	newShortCode := uint64(rand.Intn(_randMax))
-	newShortUrl := lo.Must(utils.Radix64Encode(newShortCode))
+	return c.CreateRandomShortUrlInGroup(longUrl, userId, _defaultUrlGroupId)
+}
 
-	url = &models.Url{
-		ID:         newShortCode,
-		ShortURL:   newShortUrl,
-		LongURL:    longUrl,
-		CreatorID:  userId,
-		UrlGroupID: 0,
+func (c *UrlsController) CreateRandomShortUrlInGroup(longUrl string, userId uint64, urlGroupID uint64) (url *models.Url, err error) {
+	if err := c.ensureUrlGroupOwnership(urlGroupID, userId); err != nil {
+		return nil, err
 	}
-	res := c.db.Create(url)
-	if res.Error != nil {
+
+	for attempt := 0; attempt < _maxRandomShortUrlRetries; attempt++ {
+		newShortCode := uint64(rand.Intn(_randMax))
+		newShortUrl := lo.Must(utils.Radix64Encode(newShortCode))
+
+		url = &models.Url{
+			ID:         newShortCode,
+			ShortURL:   newShortUrl,
+			LongURL:    longUrl,
+			CreatorID:  userId,
+			UrlGroupID: urlGroupID,
+		}
+
+		res := c.db.Create(url)
+		if res.Error == nil {
+			return url, nil
+		}
 		if errors.Is(res.Error, gorm.ErrDuplicatedKey) {
-			// Having a collision is very unlikely, but if it happens
-			// we just try again (TODO: we should have a limit of retries)
-			return c.CreateRandomShortUrl(longUrl, userId)
+			continue
 		}
 		return nil, res.Error
 	}
 
-	return
+	return nil, RandomShortUrlExhaustedError
 }
 
 func (c *UrlsController) GetUrlWithShortCode(shortcode string) (url *models.Url, err error) {
+	return c.GetUrlWithShortCodeInGroup(shortcode, _defaultUrlGroupId)
+}
+
+func (c *UrlsController) GetUrlWithShortCodeInGroup(shortcode string, urlGroupID uint64) (url *models.Url, err error) {
 	url = &models.Url{}
-	id := lo.Must(utils.Radix64Decode(shortcode))
-	res := c.db.First(url, id)
+	res := c.db.Where("url_group_id = ? AND short_url = ?", urlGroupID, shortcode).First(url)
 	if res.Error != nil {
 		if errors.Is(res.Error, gorm.ErrRecordNotFound) {
 			return nil, UrlNotFound
@@ -157,10 +191,25 @@ func (c *UrlsController) CreateUrlGroup(groupName string, userId uint64) (urlGro
 
 	res := c.db.Create(urlGroup)
 	if res.Error != nil {
-
+		if errors.Is(res.Error, gorm.ErrDuplicatedKey) {
+			return nil, UrlGroupExistsError
+		}
+		return nil, res.Error
 	}
-	return
+	return urlGroup, nil
 
+}
+
+func (c *UrlsController) GetUrlGroupByShortPath(groupName string) (urlGroup *models.UrlGroup, err error) {
+	urlGroup = &models.UrlGroup{}
+	res := c.db.Where("name = ?", groupName).First(urlGroup)
+	if res.Error != nil {
+		if errors.Is(res.Error, gorm.ErrRecordNotFound) {
+			return nil, UrlGroupNotFound
+		}
+		return nil, res.Error
+	}
+	return urlGroup, nil
 }
 
 func (c *UrlsController) GetUrlInfo(shortcode string) (longUrl string, hitCount int64, err error) {
@@ -188,4 +237,23 @@ func (c *UrlsController) GetUrls(userId *uint64) ([]models.Url, error) {
 		return nil, res.Error
 	}
 	return urls, nil
+}
+
+func (c *UrlsController) ensureUrlGroupOwnership(urlGroupID uint64, userID uint64) error {
+	if urlGroupID == _defaultUrlGroupId {
+		return nil
+	}
+
+	urlGroup := &models.UrlGroup{}
+	res := c.db.First(urlGroup, urlGroupID)
+	if res.Error != nil {
+		if errors.Is(res.Error, gorm.ErrRecordNotFound) {
+			return UrlGroupNotFound
+		}
+		return res.Error
+	}
+	if urlGroup.CreatorID != userID {
+		return UrlForbiddenError
+	}
+	return nil
 }

--- a/src/controllers/urls.go
+++ b/src/controllers/urls.go
@@ -62,7 +62,7 @@ var initDefaultUrlGroupOnce sync.Once
 func (c *UrlsController) initDefaultUrlGroup() {
 	defaultUrlGroup := &models.UrlGroup{
 		ID:        _defaultUrlGroupId,
-		Name:      lo.Must(utils.Radix64Encode(_defaultUrlGroupId)), // "0",
+		ShortPath: lo.Must(utils.Radix64Encode(_defaultUrlGroupId)), // "0",
 		CreatorID: 0,
 	}
 
@@ -150,7 +150,7 @@ func (c *UrlsController) GetUrlWithShortCode(shortcode string) (url *models.Url,
 
 func (c *UrlsController) CreateUrlGroup(groupName string, userId uint64) (urlGroup *models.UrlGroup, err error) {
 	urlGroup = &models.UrlGroup{
-		Name:      groupName,
+		ShortPath: groupName,
 		ID:        lo.Must(utils.Radix64Decode(groupName)),
 		CreatorID: userId,
 	}

--- a/src/controllers/urls_test.go
+++ b/src/controllers/urls_test.go
@@ -1,6 +1,7 @@
 package controllers
 
 import (
+	"errors"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"onepixel_backend/src/db/models"
@@ -39,6 +40,61 @@ func TestUrlsController(t *testing.T) {
 		urlGroup, err := urlsController.CreateUrlGroup("grp", user.ID)
 		assert.Nil(t, err)
 		assert.NotNil(t, urlGroup)
+	})
+
+	t.Run("CreateUrlGroupDuplicateFail", func(t *testing.T) {
+		_, err := urlsController.CreateUrlGroup("dupgrp", user.ID)
+		assert.Nil(t, err)
+
+		_, err = urlsController.CreateUrlGroup("dupgrp", user.ID)
+		assert.ErrorIs(t, err, UrlGroupExistsError)
+	})
+
+	t.Run("GroupedUrlsRequireOwnership", func(t *testing.T) {
+		otherUser, _, err := userController.Create("user24680@test.com", "123456")
+		assert.Nil(t, err)
+
+		urlGroup, err := urlsController.CreateUrlGroup("grpown", user.ID)
+		assert.Nil(t, err)
+
+		groupedUrl, err := urlsController.CreateSpecificShortUrlInGroup("ownabc", "https://owner.example.com", user.ID, urlGroup.ID)
+		assert.Nil(t, err)
+		assert.EqualValues(t, urlGroup.ID, groupedUrl.UrlGroupID)
+
+		_, err = urlsController.CreateRandomShortUrlInGroup("https://forbidden.example.com", otherUser.ID, urlGroup.ID)
+		assert.ErrorIs(t, err, UrlGroupForbiddenError)
+	})
+
+	t.Run("GroupedAndUngroupedLookupsAreScoped", func(t *testing.T) {
+		urlGroup, err := urlsController.CreateUrlGroup("grpdup", user.ID)
+		assert.Nil(t, err)
+
+		groupedUrl, err := urlsController.CreateSpecificShortUrlInGroup("same01", "https://group.example.com", user.ID, urlGroup.ID)
+		assert.Nil(t, err)
+		assert.EqualValues(t, urlGroup.ID, groupedUrl.UrlGroupID)
+
+		ungroupedUrl, err := urlsController.CreateSpecificShortUrl("same01", "https://default.example.com", user.ID)
+		assert.Nil(t, err)
+		assert.EqualValues(t, uint64(0), ungroupedUrl.UrlGroupID)
+
+		defaultLookup, err := urlsController.GetUrlWithShortCode("same01")
+		assert.Nil(t, err)
+		assert.Equal(t, "https://default.example.com", defaultLookup.LongURL)
+		assert.EqualValues(t, uint64(0), defaultLookup.UrlGroupID)
+
+		groupedLookup, err := urlsController.GetUrlWithShortCodeInGroup("same01", urlGroup.ID)
+		assert.Nil(t, err)
+		assert.Equal(t, "https://group.example.com", groupedLookup.LongURL)
+		assert.EqualValues(t, urlGroup.ID, groupedLookup.UrlGroupID)
+
+		lookupGroup, err := urlsController.GetUrlGroupByShortPath("grpdup")
+		assert.Nil(t, err)
+		assert.EqualValues(t, urlGroup.ID, lookupGroup.ID)
+	})
+
+	t.Run("MissingUrlGroupReturnsTypedError", func(t *testing.T) {
+		_, err := urlsController.GetUrlGroupByShortPath("missinggrp")
+		assert.True(t, errors.Is(err, UrlGroupNotFound))
 	})
 
 	t.Run("GetUrlInfo", func(t *testing.T) {
@@ -102,5 +158,10 @@ func TestUrlsController(t *testing.T) {
 			return item.ShortURL == "test777"
 		})
 		assert.True(t, found)
+		groupedUrl, ok := lo.Find(urls, func(item models.Url) bool {
+			return item.UrlGroupID != 0
+		})
+		assert.True(t, ok)
+		assert.NotEmpty(t, groupedUrl.UrlGroup.ShortPath)
 	})
 }

--- a/src/db/init.go
+++ b/src/db/init.go
@@ -23,6 +23,9 @@ var createAppDbOnce sync.Once
 var createEventsDbOnce sync.Once
 var createGeoIPDbOnce sync.Once
 
+const urlGroupShortPathIndexName = "idx_url_groups_short_path"
+const urlGroupScopedShortCodeIndexName = "idx_urls_group_shortcode"
+
 func getGormConfig() (dbConfig *gorm.Config) {
 	dbConfig = &gorm.Config{
 		TranslateError: true,
@@ -73,9 +76,39 @@ func GetAppDB() *gorm.DB {
 		lo.Must0(appDb.AutoMigrate(&models.User{}))
 		lo.Must0(appDb.AutoMigrate(&models.UrlGroup{}))
 		lo.Must0(appDb.AutoMigrate(&models.Url{}))
+		lo.Must0(ensureAppIndexes(appDb))
 	})
 
 	return appDb
+}
+
+func ensureAppIndexes(appDb *gorm.DB) error {
+	migrator := appDb.Migrator()
+
+	for _, legacyIndexName := range []string{"idx_urls_short_url", "uni_urls_short_url"} {
+		if migrator.HasIndex(&models.Url{}, legacyIndexName) {
+			applogger.Warn("App: dropping legacy urls short_url index ", legacyIndexName)
+			if err := migrator.DropIndex(&models.Url{}, legacyIndexName); err != nil {
+				return err
+			}
+		}
+	}
+
+	if !migrator.HasIndex(&models.UrlGroup{}, urlGroupShortPathIndexName) {
+		applogger.Info("App: creating url_groups short path index")
+		if err := migrator.CreateIndex(&models.UrlGroup{}, urlGroupShortPathIndexName); err != nil {
+			return err
+		}
+	}
+
+	if !migrator.HasIndex(&models.Url{}, urlGroupScopedShortCodeIndexName) {
+		applogger.Info("App: creating urls scoped shortcode index")
+		if err := migrator.CreateIndex(&models.Url{}, urlGroupScopedShortCodeIndexName); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func GetEventsDB() *gorm.DB {

--- a/src/db/models/url.go
+++ b/src/db/models/url.go
@@ -6,11 +6,11 @@ import "gorm.io/gorm"
 type Url struct {
 	gorm.Model
 	ID         uint64   `gorm:"primaryKey;autoIncrement:false"`
-	ShortURL   string   `gorm:"unique,not null,size:10"`
+	ShortURL   string   `gorm:"not null;size:10;uniqueIndex:idx_urls_group_shortcode,priority:2"`
 	LongURL    string   `gorm:"not null"`
 	CreatorID  uint64   `gorm:"not null"`
 	Creator    User     `gorm:"foreignKey:CreatorID"`
-	UrlGroupID uint64   `gorm:"primaryKey;not null, default:0"`
+	UrlGroupID uint64   `gorm:"primaryKey;not null;default:0;uniqueIndex:idx_urls_group_shortcode,priority:1"`
 	UrlGroup   UrlGroup `gorm:"foreignKey:UrlGroupID"`
 }
 

--- a/src/db/models/url_group.go
+++ b/src/db/models/url_group.go
@@ -5,7 +5,7 @@ import "gorm.io/gorm"
 type UrlGroup struct {
 	gorm.Model
 	ID        uint64 `gorm:"primaryKey;autoIncrement:false"`
-	Name      string `gorm:"unique,not null,size:10"`
+	ShortPath string `gorm:"column:name;not null;size:10;uniqueIndex:idx_url_groups_short_path"`
 	CreatorID uint64 `gorm:"not null"`
 	Creator   User   `gorm:"foreignKey:CreatorID"`
 }

--- a/src/docs/docs.go
+++ b/src/docs/docs.go
@@ -110,6 +110,219 @@ const docTemplate = `{
                 }
             }
         },
+        "/urls/groups": {
+            "post": {
+                "security": [
+                    {
+                        "APIKeyAuth": []
+                    }
+                ],
+                "description": "Create a URL group for a specific user",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "urls"
+                ],
+                "summary": "Create URL group",
+                "operationId": "create-url-group",
+                "parameters": [
+                    {
+                        "description": "URL group",
+                        "name": "urlGroup",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dtos.CreateUrlGroupRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/dtos.UrlGroupResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "The request body is not valid",
+                        "schema": {
+                            "$ref": "#/definitions/dtos.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "URL group already exists",
+                        "schema": {
+                            "$ref": "#/definitions/dtos.ErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "invalid group",
+                        "schema": {
+                            "$ref": "#/definitions/dtos.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/urls/groups/{group}/shorten": {
+            "post": {
+                "security": [
+                    {
+                        "BearerToken": []
+                    }
+                ],
+                "description": "Create a grouped short URL for a URL group owned by the authenticated user",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "urls"
+                ],
+                "summary": "Create grouped short URL with random shortcode",
+                "operationId": "create-grouped-random-url",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "URL group",
+                        "name": "group",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Url",
+                        "name": "url",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dtos.CreateUrlRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/dtos.UrlResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "The request body is not valid",
+                        "schema": {
+                            "$ref": "#/definitions/dtos.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "URL group does not belong to the user",
+                        "schema": {
+                            "$ref": "#/definitions/dtos.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "URL group not found",
+                        "schema": {
+                            "$ref": "#/definitions/dtos.ErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "invalid group",
+                        "schema": {
+                            "$ref": "#/definitions/dtos.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/urls/groups/{group}/shorten/{shortcode}": {
+            "post": {
+                "security": [
+                    {
+                        "BearerToken": []
+                    }
+                ],
+                "description": "Create a grouped short URL for a URL group owned by the authenticated user",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "urls"
+                ],
+                "summary": "Create grouped short URL with specific shortcode",
+                "operationId": "create-grouped-specific-url",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "URL group",
+                        "name": "group",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Shortcode",
+                        "name": "shortcode",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Url",
+                        "name": "url",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dtos.CreateUrlRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/dtos.UrlResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "The request body is not valid",
+                        "schema": {
+                            "$ref": "#/definitions/dtos.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "URL group does not belong to the user",
+                        "schema": {
+                            "$ref": "#/definitions/dtos.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "URL group not found",
+                        "schema": {
+                            "$ref": "#/definitions/dtos.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "URL already exists",
+                        "schema": {
+                            "$ref": "#/definitions/dtos.ErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "invalid shortcode",
+                        "schema": {
+                            "$ref": "#/definitions/dtos.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/urls/{shortcode}": {
             "get": {
                 "description": "Get URL info",
@@ -361,6 +574,15 @@ const docTemplate = `{
                         "name": "userid",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "description": "User",
+                        "name": "user",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dtos.UpdateUserRequest"
+                        }
                     }
                 ],
                 "responses": {}
@@ -368,6 +590,17 @@ const docTemplate = `{
         }
     },
     "definitions": {
+        "dtos.CreateUrlGroupRequest": {
+            "type": "object",
+            "properties": {
+                "creator_id": {
+                    "type": "integer"
+                },
+                "short_path": {
+                    "type": "string"
+                }
+            }
+        },
         "dtos.CreateUrlRequest": {
             "type": "object",
             "properties": {
@@ -408,6 +641,27 @@ const docTemplate = `{
                 },
                 "password": {
                     "type": "string"
+                }
+            }
+        },
+        "dtos.UpdateUserRequest": {
+            "type": "object",
+            "properties": {
+                "password": {
+                    "type": "string"
+                }
+            }
+        },
+        "dtos.UrlGroupResponse": {
+            "type": "object",
+            "properties": {
+                "creator_id": {
+                    "type": "integer",
+                    "example": 1
+                },
+                "short_path": {
+                    "type": "string",
+                    "example": "teamA"
                 }
             }
         },

--- a/src/docs/swagger.json
+++ b/src/docs/swagger.json
@@ -108,6 +108,219 @@
                 }
             }
         },
+        "/urls/groups": {
+            "post": {
+                "security": [
+                    {
+                        "APIKeyAuth": []
+                    }
+                ],
+                "description": "Create a URL group for a specific user",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "urls"
+                ],
+                "summary": "Create URL group",
+                "operationId": "create-url-group",
+                "parameters": [
+                    {
+                        "description": "URL group",
+                        "name": "urlGroup",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dtos.CreateUrlGroupRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/dtos.UrlGroupResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "The request body is not valid",
+                        "schema": {
+                            "$ref": "#/definitions/dtos.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "URL group already exists",
+                        "schema": {
+                            "$ref": "#/definitions/dtos.ErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "invalid group",
+                        "schema": {
+                            "$ref": "#/definitions/dtos.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/urls/groups/{group}/shorten": {
+            "post": {
+                "security": [
+                    {
+                        "BearerToken": []
+                    }
+                ],
+                "description": "Create a grouped short URL for a URL group owned by the authenticated user",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "urls"
+                ],
+                "summary": "Create grouped short URL with random shortcode",
+                "operationId": "create-grouped-random-url",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "URL group",
+                        "name": "group",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Url",
+                        "name": "url",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dtos.CreateUrlRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/dtos.UrlResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "The request body is not valid",
+                        "schema": {
+                            "$ref": "#/definitions/dtos.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "URL group does not belong to the user",
+                        "schema": {
+                            "$ref": "#/definitions/dtos.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "URL group not found",
+                        "schema": {
+                            "$ref": "#/definitions/dtos.ErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "invalid group",
+                        "schema": {
+                            "$ref": "#/definitions/dtos.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/urls/groups/{group}/shorten/{shortcode}": {
+            "post": {
+                "security": [
+                    {
+                        "BearerToken": []
+                    }
+                ],
+                "description": "Create a grouped short URL for a URL group owned by the authenticated user",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "urls"
+                ],
+                "summary": "Create grouped short URL with specific shortcode",
+                "operationId": "create-grouped-specific-url",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "URL group",
+                        "name": "group",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Shortcode",
+                        "name": "shortcode",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Url",
+                        "name": "url",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dtos.CreateUrlRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/dtos.UrlResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "The request body is not valid",
+                        "schema": {
+                            "$ref": "#/definitions/dtos.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "URL group does not belong to the user",
+                        "schema": {
+                            "$ref": "#/definitions/dtos.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "URL group not found",
+                        "schema": {
+                            "$ref": "#/definitions/dtos.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "URL already exists",
+                        "schema": {
+                            "$ref": "#/definitions/dtos.ErrorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "invalid shortcode",
+                        "schema": {
+                            "$ref": "#/definitions/dtos.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/urls/{shortcode}": {
             "get": {
                 "description": "Get URL info",
@@ -359,6 +572,15 @@
                         "name": "userid",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "description": "User",
+                        "name": "user",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dtos.UpdateUserRequest"
+                        }
                     }
                 ],
                 "responses": {}
@@ -366,6 +588,17 @@
         }
     },
     "definitions": {
+        "dtos.CreateUrlGroupRequest": {
+            "type": "object",
+            "properties": {
+                "creator_id": {
+                    "type": "integer"
+                },
+                "short_path": {
+                    "type": "string"
+                }
+            }
+        },
         "dtos.CreateUrlRequest": {
             "type": "object",
             "properties": {
@@ -406,6 +639,27 @@
                 },
                 "password": {
                     "type": "string"
+                }
+            }
+        },
+        "dtos.UpdateUserRequest": {
+            "type": "object",
+            "properties": {
+                "password": {
+                    "type": "string"
+                }
+            }
+        },
+        "dtos.UrlGroupResponse": {
+            "type": "object",
+            "properties": {
+                "creator_id": {
+                    "type": "integer",
+                    "example": 1
+                },
+                "short_path": {
+                    "type": "string",
+                    "example": "teamA"
                 }
             }
         },

--- a/src/docs/swagger.yaml
+++ b/src/docs/swagger.yaml
@@ -1,5 +1,12 @@
 basePath: /api/v1
 definitions:
+  dtos.CreateUrlGroupRequest:
+    properties:
+      creator_id:
+        type: integer
+      short_path:
+        type: string
+    type: object
   dtos.CreateUrlRequest:
     properties:
       long_url:
@@ -26,6 +33,20 @@ definitions:
       email:
         type: string
       password:
+        type: string
+    type: object
+  dtos.UpdateUserRequest:
+    properties:
+      password:
+        type: string
+    type: object
+  dtos.UrlGroupResponse:
+    properties:
+      creator_id:
+        example: 1
+        type: integer
+      short_path:
+        example: teamA
         type: string
     type: object
   dtos.UrlInfoResponse:
@@ -205,6 +226,146 @@ paths:
       summary: Create specific short url
       tags:
       - urls
+  /urls/groups:
+    post:
+      consumes:
+      - application/json
+      description: Create a URL group for a specific user
+      operationId: create-url-group
+      parameters:
+      - description: URL group
+        in: body
+        name: urlGroup
+        required: true
+        schema:
+          $ref: '#/definitions/dtos.CreateUrlGroupRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/dtos.UrlGroupResponse'
+        "400":
+          description: The request body is not valid
+          schema:
+            $ref: '#/definitions/dtos.ErrorResponse'
+        "409":
+          description: URL group already exists
+          schema:
+            $ref: '#/definitions/dtos.ErrorResponse'
+        "422":
+          description: invalid group
+          schema:
+            $ref: '#/definitions/dtos.ErrorResponse'
+      security:
+      - APIKeyAuth: []
+      summary: Create URL group
+      tags:
+      - urls
+  /urls/groups/{group}/shorten:
+    post:
+      consumes:
+      - application/json
+      description: Create a grouped short URL for a URL group owned by the authenticated
+        user
+      operationId: create-grouped-random-url
+      parameters:
+      - description: URL group
+        in: path
+        name: group
+        required: true
+        type: string
+      - description: Url
+        in: body
+        name: url
+        required: true
+        schema:
+          $ref: '#/definitions/dtos.CreateUrlRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/dtos.UrlResponse'
+        "400":
+          description: The request body is not valid
+          schema:
+            $ref: '#/definitions/dtos.ErrorResponse'
+        "403":
+          description: URL group does not belong to the user
+          schema:
+            $ref: '#/definitions/dtos.ErrorResponse'
+        "404":
+          description: URL group not found
+          schema:
+            $ref: '#/definitions/dtos.ErrorResponse'
+        "422":
+          description: invalid group
+          schema:
+            $ref: '#/definitions/dtos.ErrorResponse'
+      security:
+      - BearerToken: []
+      summary: Create grouped short URL with random shortcode
+      tags:
+      - urls
+  /urls/groups/{group}/shorten/{shortcode}:
+    post:
+      consumes:
+      - application/json
+      description: Create a grouped short URL for a URL group owned by the authenticated
+        user
+      operationId: create-grouped-specific-url
+      parameters:
+      - description: URL group
+        in: path
+        name: group
+        required: true
+        type: string
+      - description: Shortcode
+        in: path
+        name: shortcode
+        required: true
+        type: string
+      - description: Url
+        in: body
+        name: url
+        required: true
+        schema:
+          $ref: '#/definitions/dtos.CreateUrlRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/dtos.UrlResponse'
+        "400":
+          description: The request body is not valid
+          schema:
+            $ref: '#/definitions/dtos.ErrorResponse'
+        "403":
+          description: URL group does not belong to the user
+          schema:
+            $ref: '#/definitions/dtos.ErrorResponse'
+        "404":
+          description: URL group not found
+          schema:
+            $ref: '#/definitions/dtos.ErrorResponse'
+        "409":
+          description: URL already exists
+          schema:
+            $ref: '#/definitions/dtos.ErrorResponse'
+        "422":
+          description: invalid shortcode
+          schema:
+            $ref: '#/definitions/dtos.ErrorResponse'
+      security:
+      - BearerToken: []
+      summary: Create grouped short URL with specific shortcode
+      tags:
+      - urls
   /users:
     post:
       consumes:
@@ -271,6 +432,12 @@ paths:
         name: userid
         required: true
         type: integer
+      - description: User
+        in: body
+        name: user
+        required: true
+        schema:
+          $ref: '#/definitions/dtos.UpdateUserRequest'
       produces:
       - application/json
       responses: {}

--- a/src/dtos/url_dtos.go
+++ b/src/dtos/url_dtos.go
@@ -11,11 +11,21 @@ type CreateUrlRequest struct {
 	LongUrl string `json:"long_url"`
 }
 
+type CreateUrlGroupRequest struct {
+	ShortPath string `json:"short_path"`
+	CreatorID uint64 `json:"creator_id"`
+}
+
 /// Responses
 
 type UrlResponse struct {
 	ShortURL  string `json:"short_url" example:"https://1px.li/nhg145"` // Example url will pick up host and protocol(http/https) based on the env
 	LongURL   string `json:"long_url" example:"https://www.google.com"`
+	CreatorID uint64 `json:"creator_id" example:"1"`
+}
+
+type UrlGroupResponse struct {
+	ShortPath string `json:"short_path" example:"teamA"`
 	CreatorID uint64 `json:"creator_id" example:"1"`
 }
 
@@ -27,10 +37,21 @@ type UrlInfoResponse struct {
 /// Converters
 
 func CreateUrlResponse(url *models.Url) UrlResponse {
+	shortURL := url.ShortURL
+	if url.UrlGroupID != 0 && url.UrlGroup.ShortPath != "" {
+		shortURL = url.UrlGroup.ShortPath + "/" + shortURL
+	}
 	return UrlResponse{
-		ShortURL:  config.RedirUrlBase + url.ShortURL,
+		ShortURL:  config.RedirUrlBase + shortURL,
 		LongURL:   url.LongURL,
 		CreatorID: url.CreatorID,
+	}
+}
+
+func CreateUrlGroupResponse(group *models.UrlGroup) UrlGroupResponse {
+	return UrlGroupResponse{
+		ShortPath: group.ShortPath,
+		CreatorID: group.CreatorID,
 	}
 }
 

--- a/src/routes/api/urls.go
+++ b/src/routes/api/urls.go
@@ -168,6 +168,21 @@ func createSpecificUrl(ctx *fiber.Ctx) error {
 	return ctx.Status(fiber.StatusCreated).JSON(dtos.CreateUrlResponse(createdUrl))
 }
 
+// createUrlGroup
+//
+//	@Summary		Create URL group
+//	@Description	Create a URL group for a specific user
+//	@ID				create-url-group
+//	@Tags			urls
+//	@Accept			json
+//	@Produce		json
+//	@Param			urlGroup	body		dtos.CreateUrlGroupRequest	true	"URL group"
+//	@Success		201			{object}	dtos.UrlGroupResponse
+//	@Failure		400			{object}	dtos.ErrorResponse	"The request body is not valid"
+//	@Failure		409			{object}	dtos.ErrorResponse	"URL group already exists"
+//	@Failure		422			{object}	dtos.ErrorResponse	"invalid group"
+//	@Router			/urls/groups [post]
+//	@Security		APIKeyAuth
 func createUrlGroup(ctx *fiber.Ctx) error {
 	cur, parseErr := parsers.ParseBody[dtos.CreateUrlGroupRequest](ctx)
 	if parseErr != nil {
@@ -187,37 +202,33 @@ func createUrlGroup(ctx *fiber.Ctx) error {
 	return ctx.Status(fiber.StatusCreated).JSON(dtos.CreateUrlGroupResponse(urlGroup))
 }
 
-func createGroupedRandomUrl(ctx *fiber.Ctx) error {
-	user := ctx.Locals(config.LOCALS_USER).(*models.User)
-	urlGroup, groupErr := getOwnedUrlGroup(ctx, user)
-	if groupErr != nil {
-		return groupErr
-	}
-
-	cur, parseErr := parsers.ParseBody[dtos.CreateUrlRequest](ctx)
-	if parseErr != nil {
-		return parsers.SendParsingError(ctx, parseErr)
-	}
-
-	validErr := validators.ValidateCreateUrlRequest(cur)
-	if validErr != nil {
-		return validators.SendValidationError(ctx, validErr)
-	}
-
-	createdUrl, createErr := urlsController.CreateRandomShortUrlInGroup(cur.LongUrl, user.ID, urlGroup.ID)
-	if createErr != nil {
-		return sendUrlControllerError(ctx, createErr)
-	}
-
-	createdUrl.UrlGroup = *urlGroup
-	return ctx.Status(fiber.StatusCreated).JSON(dtos.CreateUrlResponse(createdUrl))
-}
-
+// createGroupedSpecificUrl
+//
+//	@Summary		Create grouped short URL with specific shortcode
+//	@Description	Create a grouped short URL for a URL group owned by the authenticated user
+//	@ID				create-grouped-specific-url
+//	@Tags			urls
+//	@Accept			json
+//	@Produce		json
+//	@Param			group		path		string					true	"URL group"
+//	@Param			shortcode	path		string					true	"Shortcode"
+//	@Param			url			body		dtos.CreateUrlRequest	true	"Url"
+//	@Success		201			{object}	dtos.UrlResponse
+//	@Failure		400			{object}	dtos.ErrorResponse	"The request body is not valid"
+//	@Failure		403			{object}	dtos.ErrorResponse	"URL group does not belong to the user"
+//	@Failure		404			{object}	dtos.ErrorResponse	"URL group not found"
+//	@Failure		409			{object}	dtos.ErrorResponse	"URL already exists"
+//	@Failure		422			{object}	dtos.ErrorResponse	"invalid shortcode"
+//	@Router			/urls/groups/{group}/shorten/{shortcode} [post]
+//	@Security		BearerToken
 func createGroupedSpecificUrl(ctx *fiber.Ctx) error {
 	user := ctx.Locals(config.LOCALS_USER).(*models.User)
-	urlGroup, groupErr := getOwnedUrlGroup(ctx, user)
+	urlGroup, handled, groupErr := getOwnedUrlGroup(ctx, user)
 	if groupErr != nil {
 		return groupErr
+	}
+	if handled {
+		return nil
 	}
 
 	cur, parseErr := parsers.ParseBody[dtos.CreateUrlRequest](ctx)
@@ -237,6 +248,52 @@ func createGroupedSpecificUrl(ctx *fiber.Ctx) error {
 	}
 
 	createdUrl, createErr := urlsController.CreateSpecificShortUrlInGroup(shortcode, cur.LongUrl, user.ID, urlGroup.ID)
+	if createErr != nil {
+		return sendUrlControllerError(ctx, createErr)
+	}
+
+	createdUrl.UrlGroup = *urlGroup
+	return ctx.Status(fiber.StatusCreated).JSON(dtos.CreateUrlResponse(createdUrl))
+}
+
+// createGroupedRandomUrl
+//
+//	@Summary		Create grouped short URL with random shortcode
+//	@Description	Create a grouped short URL for a URL group owned by the authenticated user
+//	@ID				create-grouped-random-url
+//	@Tags			urls
+//	@Accept			json
+//	@Produce		json
+//	@Param			group	path		string					true	"URL group"
+//	@Param			url		body		dtos.CreateUrlRequest	true	"Url"
+//	@Success		201		{object}	dtos.UrlResponse
+//	@Failure		400		{object}	dtos.ErrorResponse	"The request body is not valid"
+//	@Failure		403		{object}	dtos.ErrorResponse	"URL group does not belong to the user"
+//	@Failure		404		{object}	dtos.ErrorResponse	"URL group not found"
+//	@Failure		422		{object}	dtos.ErrorResponse	"invalid group"
+//	@Router			/urls/groups/{group}/shorten [post]
+//	@Security		BearerToken
+func createGroupedRandomUrl(ctx *fiber.Ctx) error {
+	user := ctx.Locals(config.LOCALS_USER).(*models.User)
+	urlGroup, handled, groupErr := getOwnedUrlGroup(ctx, user)
+	if groupErr != nil {
+		return groupErr
+	}
+	if handled {
+		return nil
+	}
+
+	cur, parseErr := parsers.ParseBody[dtos.CreateUrlRequest](ctx)
+	if parseErr != nil {
+		return parsers.SendParsingError(ctx, parseErr)
+	}
+
+	validErr := validators.ValidateCreateUrlRequest(cur)
+	if validErr != nil {
+		return validators.SendValidationError(ctx, validErr)
+	}
+
+	createdUrl, createErr := urlsController.CreateRandomShortUrlInGroup(cur.LongUrl, user.ID, urlGroup.ID)
 	if createErr != nil {
 		return sendUrlControllerError(ctx, createErr)
 	}
@@ -271,22 +328,22 @@ func getUrlInfo(ctx *fiber.Ctx) error {
 	return ctx.Status(fiber.StatusOK).JSON(dtos.CreateUrlInfoResponse(longUrl, hitCount))
 }
 
-func getOwnedUrlGroup(ctx *fiber.Ctx, user *models.User) (*models.UrlGroup, error) {
+func getOwnedUrlGroup(ctx *fiber.Ctx, user *models.User) (*models.UrlGroup, bool, error) {
 	group := ctx.Params("group")
 	validErr := validators.ValidateCreateUrlGroupRequest(group)
 	if validErr != nil {
-		return nil, validators.SendValidationError(ctx, validErr)
+		return nil, true, validators.SendValidationError(ctx, validErr)
 	}
 
 	urlGroup, groupErr := urlsController.GetUrlGroupByShortPath(group)
 	if groupErr != nil {
-		return nil, sendUrlControllerError(ctx, groupErr)
+		return nil, true, sendUrlControllerError(ctx, groupErr)
 	}
 	if urlGroup.CreatorID != user.ID {
-		return nil, ctx.Status(fiber.StatusForbidden).JSON(dtos.CreateErrorResponse(controllers.UrlGroupForbiddenError.ErrorDetails()))
+		return nil, true, ctx.Status(fiber.StatusForbidden).JSON(dtos.CreateErrorResponse(controllers.UrlGroupForbiddenError.ErrorDetails()))
 	}
 
-	return urlGroup, nil
+	return urlGroup, false, nil
 }
 
 func sendUrlControllerError(ctx *fiber.Ctx, err error) error {

--- a/src/routes/api/urls.go
+++ b/src/routes/api/urls.go
@@ -162,49 +162,87 @@ func createSpecificUrl(ctx *fiber.Ctx) error {
 
 	createdUrl, createErr := urlsController.CreateSpecificShortUrl(shortcode, cur.LongUrl, user.ID)
 	if createErr != nil {
-		var e *controllers.UrlError
-		if errors.As(createErr, &e) {
-			if errors.Is(e, controllers.UrlExistsError) {
-				return ctx.Status(fiber.StatusConflict).JSON(dtos.CreateErrorResponse(e.ErrorDetails()))
-			}
-			if errors.Is(e, controllers.UrlForbiddenError) {
-				return ctx.Status(fiber.StatusForbidden).JSON(dtos.CreateErrorResponse(e.ErrorDetails()))
-			}
-		} else {
-			return ctx.Status(fiber.StatusInternalServerError).JSON(dtos.CreateErrorResponse(fiber.StatusInternalServerError, "something went wrong"))
-		}
+		return sendUrlControllerError(ctx, createErr)
 	}
 
 	return ctx.Status(fiber.StatusCreated).JSON(dtos.CreateUrlResponse(createdUrl))
 }
 
 func createUrlGroup(ctx *fiber.Ctx) error {
-	return ctx.Status(fiber.StatusNotImplemented).JSON(dtos.CreateErrorResponse(fiber.StatusNotImplemented, "URL group creation is not implemented yet"))
+	cur, parseErr := parsers.ParseBody[dtos.CreateUrlGroupRequest](ctx)
+	if parseErr != nil {
+		return parsers.SendParsingError(ctx, parseErr)
+	}
+
+	validErr := validators.ValidateCreateUrlGroupDtoRequest(cur)
+	if validErr != nil {
+		return validators.SendValidationError(ctx, validErr)
+	}
+
+	urlGroup, createErr := urlsController.CreateUrlGroup(cur.ShortPath, cur.CreatorID)
+	if createErr != nil {
+		return sendUrlControllerError(ctx, createErr)
+	}
+
+	return ctx.Status(fiber.StatusCreated).JSON(dtos.CreateUrlGroupResponse(urlGroup))
 }
 
 func createGroupedRandomUrl(ctx *fiber.Ctx) error {
-	group := ctx.Params("group")
-	validErr := validators.ValidateCreateUrlGroupRequest(group)
+	user := ctx.Locals(config.LOCALS_USER).(*models.User)
+	urlGroup, groupErr := getOwnedUrlGroup(ctx, user)
+	if groupErr != nil {
+		return groupErr
+	}
+
+	cur, parseErr := parsers.ParseBody[dtos.CreateUrlRequest](ctx)
+	if parseErr != nil {
+		return parsers.SendParsingError(ctx, parseErr)
+	}
+
+	validErr := validators.ValidateCreateUrlRequest(cur)
 	if validErr != nil {
 		return validators.SendValidationError(ctx, validErr)
 	}
-	return ctx.Status(fiber.StatusNotImplemented).JSON(dtos.CreateErrorResponse(fiber.StatusNotImplemented, "Grouped URL creation is not implemented yet"))
+
+	createdUrl, createErr := urlsController.CreateRandomShortUrlInGroup(cur.LongUrl, user.ID, urlGroup.ID)
+	if createErr != nil {
+		return sendUrlControllerError(ctx, createErr)
+	}
+
+	createdUrl.UrlGroup = *urlGroup
+	return ctx.Status(fiber.StatusCreated).JSON(dtos.CreateUrlResponse(createdUrl))
 }
 
 func createGroupedSpecificUrl(ctx *fiber.Ctx) error {
-	group := ctx.Params("group")
-	validErr := validators.ValidateCreateUrlGroupRequest(group)
+	user := ctx.Locals(config.LOCALS_USER).(*models.User)
+	urlGroup, groupErr := getOwnedUrlGroup(ctx, user)
+	if groupErr != nil {
+		return groupErr
+	}
+
+	cur, parseErr := parsers.ParseBody[dtos.CreateUrlRequest](ctx)
+	if parseErr != nil {
+		return parsers.SendParsingError(ctx, parseErr)
+	}
+
+	shortcode := ctx.Params("shortcode")
+	validErr := validators.ValidateCreateUrlRequest(cur)
 	if validErr != nil {
 		return validators.SendValidationError(ctx, validErr)
 	}
 
-	shortcode := ctx.Params("shortcode")
 	validErr = validators.ValidateCreateShortCodeRequest(shortcode)
 	if validErr != nil {
 		return validators.SendValidationError(ctx, validErr)
 	}
 
-	return ctx.Status(fiber.StatusNotImplemented).JSON(dtos.CreateErrorResponse(fiber.StatusNotImplemented, "Grouped URL creation is not implemented yet"))
+	createdUrl, createErr := urlsController.CreateSpecificShortUrlInGroup(shortcode, cur.LongUrl, user.ID, urlGroup.ID)
+	if createErr != nil {
+		return sendUrlControllerError(ctx, createErr)
+	}
+
+	createdUrl.UrlGroup = *urlGroup
+	return ctx.Status(fiber.StatusCreated).JSON(dtos.CreateUrlResponse(createdUrl))
 }
 
 // getUrlInfo
@@ -220,14 +258,43 @@ func createGroupedSpecificUrl(ctx *fiber.Ctx) error {
 //	@Router			/urls/{shortcode} [get]
 func getUrlInfo(ctx *fiber.Ctx) error {
 	shortcode := ctx.Params("shortcode")
-	if shortcode == "" {
-		return ctx.Status(fiber.StatusBadRequest).JSON(dtos.CreateErrorResponse(fiber.StatusBadRequest, "shortcode is required"))
+	validErr := validators.ValidateCreateShortCodeRequest(shortcode)
+	if validErr != nil {
+		return validators.SendValidationError(ctx, validErr)
 	}
 
 	longUrl, hitCount, err := urlsController.GetUrlInfo(shortcode)
 	if err != nil {
-		return ctx.Status(fiber.StatusNotFound).JSON(dtos.CreateErrorResponse(fiber.StatusNotFound, "URL not found"))
+		return sendUrlControllerError(ctx, err)
 	}
 
 	return ctx.Status(fiber.StatusOK).JSON(dtos.CreateUrlInfoResponse(longUrl, hitCount))
+}
+
+func getOwnedUrlGroup(ctx *fiber.Ctx, user *models.User) (*models.UrlGroup, error) {
+	group := ctx.Params("group")
+	validErr := validators.ValidateCreateUrlGroupRequest(group)
+	if validErr != nil {
+		return nil, validators.SendValidationError(ctx, validErr)
+	}
+
+	urlGroup, groupErr := urlsController.GetUrlGroupByShortPath(group)
+	if groupErr != nil {
+		return nil, sendUrlControllerError(ctx, groupErr)
+	}
+	if urlGroup.CreatorID != user.ID {
+		return nil, ctx.Status(fiber.StatusForbidden).JSON(dtos.CreateErrorResponse(controllers.UrlGroupForbiddenError.ErrorDetails()))
+	}
+
+	return urlGroup, nil
+}
+
+func sendUrlControllerError(ctx *fiber.Ctx, err error) error {
+	var e *controllers.UrlError
+	if errors.As(err, &e) {
+		status, message := e.ErrorDetails()
+		return ctx.Status(status).JSON(dtos.CreateErrorResponse(status, message))
+	}
+
+	return ctx.Status(fiber.StatusInternalServerError).JSON(dtos.CreateErrorResponse(fiber.StatusInternalServerError, "something went wrong"))
 }

--- a/src/routes/api/urls.go
+++ b/src/routes/api/urls.go
@@ -23,6 +23,9 @@ func UrlsRoute() func(router fiber.Router) {
 
 	return func(router fiber.Router) {
 		router.Get("/", security.OptionalJwtAuthMiddleware, security.OptionalAdminApiKeyAuthMiddleware, getAllUrls)
+		router.Post("/groups", security.MandatoryAdminApiKeyAuthMiddleware, createUrlGroup)
+		router.Post("/groups/:group/shorten", security.MandatoryJwtAuthMiddleware, createGroupedRandomUrl)
+		router.Post("/groups/:group/shorten/:shortcode", security.MandatoryJwtAuthMiddleware, createGroupedSpecificUrl)
 		router.Post("/", security.MandatoryJwtAuthMiddleware, createRandomUrl)
 		router.Put("/:shortcode", security.MandatoryJwtAuthMiddleware, createSpecificUrl)
 		router.Get("/:shortcode", getUrlInfo)
@@ -152,9 +155,9 @@ func createSpecificUrl(ctx *fiber.Ctx) error {
 	}
 
 	shortcode := ctx.Params("shortcode")
-	if shortcode == "" {
-		// TODO: handle unacceptable/reserved shortcodes properly in controller
-		panic("shortcode is empty")
+	validErr = validators.ValidateCreateShortCodeRequest(shortcode)
+	if validErr != nil {
+		return validators.SendValidationError(ctx, validErr)
 	}
 
 	createdUrl, createErr := urlsController.CreateSpecificShortUrl(shortcode, cur.LongUrl, user.ID)
@@ -175,12 +178,33 @@ func createSpecificUrl(ctx *fiber.Ctx) error {
 	return ctx.Status(fiber.StatusCreated).JSON(dtos.CreateUrlResponse(createdUrl))
 }
 
+func createUrlGroup(ctx *fiber.Ctx) error {
+	return ctx.Status(fiber.StatusNotImplemented).JSON(dtos.CreateErrorResponse(fiber.StatusNotImplemented, "URL group creation is not implemented yet"))
+}
+
 func createGroupedRandomUrl(ctx *fiber.Ctx) error {
-	return ctx.SendString("createGroupedRandomUrl")
+	group := ctx.Params("group")
+	validErr := validators.ValidateCreateUrlGroupRequest(group)
+	if validErr != nil {
+		return validators.SendValidationError(ctx, validErr)
+	}
+	return ctx.Status(fiber.StatusNotImplemented).JSON(dtos.CreateErrorResponse(fiber.StatusNotImplemented, "Grouped URL creation is not implemented yet"))
 }
 
 func createGroupedSpecificUrl(ctx *fiber.Ctx) error {
-	return ctx.SendString("createGroupedSpecificUrl")
+	group := ctx.Params("group")
+	validErr := validators.ValidateCreateUrlGroupRequest(group)
+	if validErr != nil {
+		return validators.SendValidationError(ctx, validErr)
+	}
+
+	shortcode := ctx.Params("shortcode")
+	validErr = validators.ValidateCreateShortCodeRequest(shortcode)
+	if validErr != nil {
+		return validators.SendValidationError(ctx, validErr)
+	}
+
+	return ctx.Status(fiber.StatusNotImplemented).JSON(dtos.CreateErrorResponse(fiber.StatusNotImplemented, "Grouped URL creation is not implemented yet"))
 }
 
 // getUrlInfo

--- a/src/routes/redirect/redirect.go
+++ b/src/routes/redirect/redirect.go
@@ -18,8 +18,8 @@ func RedirectRoute() func(router fiber.Router) {
 	eventsController = controllers.CreateEventsController()
 
 	return func(router fiber.Router) {
-		router.Get("/:shortcode", redirectShortCode)
 		router.Get("/:group/:shortcode", redirectGroupedShortCode)
+		router.Get("/:shortcode", redirectShortCode)
 	}
 
 }
@@ -55,5 +55,17 @@ func redirectShortCode(ctx *fiber.Ctx) error {
 }
 
 func redirectGroupedShortCode(ctx *fiber.Ctx) error {
-	return ctx.SendString("Redirect")
+	group := ctx.Params("group")
+	validErr := validators.ValidateRedirectGroupRequest(group)
+	if validErr != nil {
+		return validators.SendValidationError(ctx, validErr)
+	}
+
+	shortcode := ctx.Params("shortcode")
+	validErr = validators.ValidateRedirectShortCodeRequest(shortcode)
+	if validErr != nil {
+		return validators.SendValidationError(ctx, validErr)
+	}
+
+	return ctx.Status(fiber.StatusNotFound).JSON(dtos.CreateErrorResponse(fiber.StatusNotFound, "URL not found"))
 }

--- a/src/routes/redirect/redirect.go
+++ b/src/routes/redirect/redirect.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"github.com/gofiber/fiber/v2"
 	"onepixel_backend/src/controllers"
+	"onepixel_backend/src/db/models"
 	"onepixel_backend/src/dtos"
 	"onepixel_backend/src/server/validators"
 	"onepixel_backend/src/utils/applogger"
@@ -34,24 +35,10 @@ func redirectShortCode(ctx *fiber.Ctx) error {
 
 	url, urlErr := urlsController.GetUrlWithShortCode(shortcode)
 	if urlErr != nil {
-		var e *controllers.UrlError
-		if errors.As(urlErr, &e) {
-			return ctx.Status(fiber.StatusNotFound).JSON(dtos.CreateErrorResponse(e.ErrorDetails()))
-		}
-		return ctx.Status(fiber.StatusInternalServerError).JSON(dtos.CreateErrorResponse(fiber.StatusInternalServerError, urlErr.Error()))
+		return sendRedirectError(ctx, urlErr)
 	}
-	eventsController.LogRedirectAsync(&controllers.EventRedirectData{
-		ShortUrlID: url.ID,
-		UrlGroupID: url.UrlGroupID,
-		ShortURL:   url.ShortURL,
-		CreatorID:  url.CreatorID,
-		IPAddress:  strings.Split(ctx.Get("X-Forwarded-For"), ",")[0],
-		UserAgent:  ctx.Get("User-Agent"),
-		Referer:    ctx.Get("Referer"),
-	})
-	// cache for 1 min only
-	// ctx.Response().Header.Set("Cache-Control", "public, max-age=60")
-	return ctx.Redirect(url.LongURL, fiber.StatusMovedPermanently)
+
+	return redirectToDestination(ctx, url, nil)
 }
 
 func redirectGroupedShortCode(ctx *fiber.Ctx) error {
@@ -67,5 +54,42 @@ func redirectGroupedShortCode(ctx *fiber.Ctx) error {
 		return validators.SendValidationError(ctx, validErr)
 	}
 
-	return ctx.Status(fiber.StatusNotFound).JSON(dtos.CreateErrorResponse(fiber.StatusNotFound, "URL not found"))
+	urlGroup, groupErr := urlsController.GetUrlGroupByShortPath(group)
+	if groupErr != nil {
+		return sendRedirectError(ctx, groupErr)
+	}
+
+	url, urlErr := urlsController.GetUrlWithShortCodeInGroup(shortcode, urlGroup.ID)
+	if urlErr != nil {
+		return sendRedirectError(ctx, urlErr)
+	}
+
+	return redirectToDestination(ctx, url, urlGroup)
+}
+
+func redirectToDestination(ctx *fiber.Ctx, url *models.Url, urlGroup *models.UrlGroup) error {
+	canonicalShortURL := controllers.CanonicalShortURL(urlGroup, url.ShortURL)
+	eventsController.LogRedirectAsync(&controllers.EventRedirectData{
+		ShortUrlID: url.ID,
+		UrlGroupID: url.UrlGroupID,
+		ShortURL:   canonicalShortURL,
+		CreatorID:  url.CreatorID,
+		IPAddress:  strings.Split(ctx.Get("X-Forwarded-For"), ",")[0],
+		UserAgent:  ctx.Get("User-Agent"),
+		Referer:    ctx.Get("Referer"),
+	})
+
+	// cache for 1 min only
+	// ctx.Response().Header.Set("Cache-Control", "public, max-age=60")
+	return ctx.Redirect(url.LongURL, fiber.StatusMovedPermanently)
+}
+
+func sendRedirectError(ctx *fiber.Ctx, err error) error {
+	var e *controllers.UrlError
+	if errors.As(err, &e) {
+		status, message := e.ErrorDetails()
+		return ctx.Status(status).JSON(dtos.CreateErrorResponse(status, message))
+	}
+
+	return ctx.Status(fiber.StatusInternalServerError).JSON(dtos.CreateErrorResponse(fiber.StatusInternalServerError, err.Error()))
 }

--- a/src/server/validators/dto_url_validators.go
+++ b/src/server/validators/dto_url_validators.go
@@ -11,6 +11,11 @@ var mandatoryUrlDtoFieldError = &ValidationError{
 	message: "long_url is required",
 }
 
+var mandatoryUrlGroupCreatorFieldError = &ValidationError{
+	status:  fiber.StatusUnprocessableEntity,
+	message: "creator_id is required",
+}
+
 var invalidShortCodeError = &ValidationError{
 	status:  fiber.StatusNotFound,
 	message: "Invalid short code",
@@ -36,6 +41,13 @@ func ValidateCreateUrlRequest(dto *dtos.CreateUrlRequest) *ValidationError {
 		return mandatoryUrlDtoFieldError
 	}
 	return nil
+}
+
+func ValidateCreateUrlGroupDtoRequest(dto *dtos.CreateUrlGroupRequest) *ValidationError {
+	if dto.CreatorID == 0 {
+		return mandatoryUrlGroupCreatorFieldError
+	}
+	return ValidateCreateUrlGroupRequest(dto.ShortPath)
 }
 
 func ValidateRedirectShortCodeRequest(shortcode string) *ValidationError {

--- a/src/server/validators/dto_url_validators.go
+++ b/src/server/validators/dto_url_validators.go
@@ -16,6 +16,21 @@ var invalidShortCodeError = &ValidationError{
 	message: "Invalid short code",
 }
 
+var invalidUrlGroupError = &ValidationError{
+	status:  fiber.StatusNotFound,
+	message: "Invalid url group",
+}
+
+var invalidCreateShortCodeError = &ValidationError{
+	status:  fiber.StatusUnprocessableEntity,
+	message: "invalid shortcode",
+}
+
+var invalidCreateUrlGroupError = &ValidationError{
+	status:  fiber.StatusUnprocessableEntity,
+	message: "invalid group",
+}
+
 func ValidateCreateUrlRequest(dto *dtos.CreateUrlRequest) *ValidationError {
 	if dto.LongUrl == "" {
 		return mandatoryUrlDtoFieldError
@@ -24,11 +39,32 @@ func ValidateCreateUrlRequest(dto *dtos.CreateUrlRequest) *ValidationError {
 }
 
 func ValidateRedirectShortCodeRequest(shortcode string) *ValidationError {
-	if shortcode == "" {
-		return invalidShortCodeError
+	return validateRadix64Token(shortcode, invalidShortCodeError)
+}
+
+func ValidateRedirectGroupRequest(group string) *ValidationError {
+	return validateRadix64Token(group, invalidUrlGroupError)
+}
+
+func ValidateCreateShortCodeRequest(shortcode string) *ValidationError {
+	return validateRadix64Token(shortcode, invalidCreateShortCodeError)
+}
+
+func ValidateCreateUrlGroupRequest(group string) *ValidationError {
+	return validateRadix64Token(group, invalidCreateUrlGroupError)
+}
+
+func validateRadix64Token(token string, err *ValidationError) *ValidationError {
+	if token == "" {
+		return err
 	}
-	if len(shortcode) > utils.MaxSafeStringLength {
-		return invalidShortCodeError
+	if len(token) > utils.MaxSafeStringLength {
+		return err
+	}
+	for _, char := range token {
+		if _, ok := utils.AlphabetIndex[char]; !ok {
+			return err
+		}
 	}
 	return nil
 }

--- a/src/server/validators/dto_url_validators_test.go
+++ b/src/server/validators/dto_url_validators_test.go
@@ -1,0 +1,50 @@
+package validators
+
+import (
+	"github.com/stretchr/testify/assert"
+	"onepixel_backend/src/dtos"
+	"testing"
+)
+
+func TestValidateCreateUrlGroupDtoRequest(t *testing.T) {
+	t.Run("Valid", func(t *testing.T) {
+		err := ValidateCreateUrlGroupDtoRequest(&dtos.CreateUrlGroupRequest{
+			ShortPath: "grp123",
+			CreatorID: 1,
+		})
+		assert.Nil(t, err)
+	})
+
+	t.Run("MissingCreatorID", func(t *testing.T) {
+		err := ValidateCreateUrlGroupDtoRequest(&dtos.CreateUrlGroupRequest{
+			ShortPath: "grp123",
+		})
+		assert.Equal(t, mandatoryUrlGroupCreatorFieldError, err)
+	})
+
+	t.Run("InvalidGroupToken", func(t *testing.T) {
+		err := ValidateCreateUrlGroupDtoRequest(&dtos.CreateUrlGroupRequest{
+			ShortPath: "bad!",
+			CreatorID: 1,
+		})
+		assert.Equal(t, invalidCreateUrlGroupError, err)
+	})
+}
+
+func TestValidateCreateShortCodeRequest(t *testing.T) {
+	t.Run("AcceptsRadix64", func(t *testing.T) {
+		assert.Nil(t, ValidateCreateShortCodeRequest("Abc_-09"))
+	})
+
+	t.Run("RejectsEmpty", func(t *testing.T) {
+		assert.Equal(t, invalidCreateShortCodeError, ValidateCreateShortCodeRequest(""))
+	})
+
+	t.Run("RejectsTooLong", func(t *testing.T) {
+		assert.Equal(t, invalidCreateShortCodeError, ValidateCreateShortCodeRequest("abcdefghijk"))
+	})
+
+	t.Run("RejectsInvalidChars", func(t *testing.T) {
+		assert.Equal(t, invalidCreateShortCodeError, ValidateCreateShortCodeRequest("bad!"))
+	})
+}

--- a/tests/e2e/url_groups_test.go
+++ b/tests/e2e/url_groups_test.go
@@ -1,0 +1,98 @@
+package e2e
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http/httptest"
+	"onepixel_backend/src/config"
+	"onepixel_backend/src/db"
+	"onepixel_backend/src/db/models"
+	"onepixel_backend/src/dtos"
+	"onepixel_backend/tests"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUrlsRoute_GroupedUrls(t *testing.T) {
+	t.Cleanup(tests.TestUtil_FlushEventsDb)
+
+	owner := tests.TestUtil_CreateUser(t, "group-owner@test.com", "123456")
+	other := tests.TestUtil_CreateUser(t, "group-other@test.com", "123456")
+
+	groupReqBody := []byte(`{"short_path":"grpE2E","creator_id":` + strconv.FormatUint(owner.ID, 10) + `}`)
+	groupReq := httptest.NewRequest("POST", "/api/v1/urls/groups", bytes.NewBuffer(groupReqBody))
+	groupReq.Header.Set("Content-Type", "application/json; charset=UTF-8")
+	groupReq.Header.Set("X-API-Key", config.AdminApiKey)
+	groupResp := lo.Must(tests.App.Test(groupReq))
+
+	assert.Equal(t, 201, groupResp.StatusCode)
+	var groupResponseBody dtos.UrlGroupResponse
+	body, err := io.ReadAll(groupResp.Body)
+	if err != nil {
+		t.Fatalf("Error reading response body: %v", err)
+	}
+	if err := json.Unmarshal(body, &groupResponseBody); err != nil {
+		t.Fatalf("Error unmarshalling response body: %v", err)
+	}
+	assert.Equal(t, "grpE2E", groupResponseBody.ShortPath)
+	assert.Equal(t, owner.ID, groupResponseBody.CreatorID)
+
+	specificReq := httptest.NewRequest("POST", "/api/v1/urls/groups/grpE2E/shorten/grp123", bytes.NewBuffer([]byte(`{"long_url":"https://example.com/grouped-specific"}`)))
+	specificReq.Header.Set("Content-Type", "application/json; charset=UTF-8")
+	specificReq.Header.Set("Authorization", *owner.Token)
+	specificResp := lo.Must(tests.App.Test(specificReq))
+
+	assert.Equal(t, 201, specificResp.StatusCode)
+	var specificUrlResponse dtos.UrlResponse
+	body, err = io.ReadAll(specificResp.Body)
+	if err != nil {
+		t.Fatalf("Error reading response body: %v", err)
+	}
+	if err := json.Unmarshal(body, &specificUrlResponse); err != nil {
+		t.Fatalf("Error unmarshalling response body: %v", err)
+	}
+	assert.Equal(t, config.RedirUrlBase+"grpE2E/grp123", specificUrlResponse.ShortURL)
+
+	randomReq := httptest.NewRequest("POST", "/api/v1/urls/groups/grpE2E/shorten", bytes.NewBuffer([]byte(`{"long_url":"https://example.com/grouped-random"}`)))
+	randomReq.Header.Set("Content-Type", "application/json; charset=UTF-8")
+	randomReq.Header.Set("Authorization", *owner.Token)
+	randomResp := lo.Must(tests.App.Test(randomReq))
+
+	assert.Equal(t, 201, randomResp.StatusCode)
+	var randomUrlResponse dtos.UrlResponse
+	body, err = io.ReadAll(randomResp.Body)
+	if err != nil {
+		t.Fatalf("Error reading response body: %v", err)
+	}
+	if err := json.Unmarshal(body, &randomUrlResponse); err != nil {
+		t.Fatalf("Error unmarshalling response body: %v", err)
+	}
+	assert.Contains(t, randomUrlResponse.ShortURL, config.RedirUrlBase+"grpE2E/")
+
+	forbiddenReq := httptest.NewRequest("POST", "/api/v1/urls/groups/grpE2E/shorten/forbid1", bytes.NewBuffer([]byte(`{"long_url":"https://example.com/forbidden"}`)))
+	forbiddenReq.Header.Set("Content-Type", "application/json; charset=UTF-8")
+	forbiddenReq.Header.Set("Authorization", *other.Token)
+	forbiddenResp := lo.Must(tests.App.Test(forbiddenReq))
+
+	assert.Equal(t, 403, forbiddenResp.StatusCode)
+
+	redirectReq := httptest.NewRequest("GET", config.RedirUrlBase+"grpE2E/grp123", nil)
+	redirectReq.Header.Set("User-Agent", "grouped-test-agent")
+	redirectReq.Header.Set("X-Forwarded-For", "42.108.28.82")
+	redirectResp := lo.Must(tests.MainApp.Test(redirectReq))
+
+	assert.Equal(t, 301, redirectResp.StatusCode)
+	assert.Equal(t, "https://example.com/grouped-specific", redirectResp.Header.Get("Location"))
+
+	time.Sleep(200 * time.Millisecond)
+
+	var redirectCount int64
+	err = db.GetEventsDB().Model(&models.EventRedirect{}).Where("short_url = ?", "grpE2E/grp123").Count(&redirectCount).Error
+	assert.Nil(t, err)
+	assert.GreaterOrEqual(t, redirectCount, int64(1))
+}


### PR DESCRIPTION
## Summary

This branch implements first-class URL groups so shortened URLs can exist in both legacy ungrouped form and grouped form:

- ungrouped: `/abcd`
- grouped: `/group/abcd`

It preserves backward compatibility for existing ungrouped URLs by keeping default group `0` as the legacy lookup path.

## What changed

- aligned grouped API and redirect route contracts
- updated URL and URL group models plus Postgres/SQLite index migration behavior
- implemented group-aware controller logic and ownership checks
- added admin-only URL group creation and grouped URL creation endpoints
- added grouped redirect resolution and canonical grouped analytics keys (`group/shortcode`)
- added unit, validator, and e2e coverage for grouped behavior
- regenerated Swagger docs for new endpoints
- added a production maintenance SQL migration for URL-group rollout

## Production notes

I audited production Postgres metadata before adding the maintenance script:

- no legacy global `short_url` index was present on `public.urls`
- default group row `id = 0` already exists
- no duplicate `url_groups.name` rows exist
- no duplicate `(url_group_id, short_url)` rows exist

A rollout-safe migration file was added at:

- `maintenance/url_groups_prod.postgres.sql`

It is intended to be run with:

```bash
psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f maintenance/url_groups_prod.postgres.sql
```

## Validation

- `make build`
- `make test`
